### PR TITLE
Position IP Restrictions

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1016,7 +1016,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 		}
 
 		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "action", "jsonrpc-authenticate");
-		switch_event_add_header_string(req_params, SWITCH_STACH_BOTTOM, "client_ip", jsock->name);
+		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "client_ip", jsock->name);
 
 		if (switch_xml_locate_user_merged("id", id, domain, NULL, &x_user, req_params) != SWITCH_STATUS_SUCCESS && !jsock->profile->blind_reg) {
 			*code = CODE_AUTH_FAILED;

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1085,7 +1085,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 				jsock->context = switch_core_strdup(jsock->pool, verto_context);
 			}
 
-			if (!strcasecmp(error_code, "ip-rejected")) {
+			if (!zstr(error_code) && !strcasecmp(error_code, "ip-rejected")) {
 				r = SWITCH_FALSE;
 				*code = CODE_IP_REJECTED;
 				switch_snprintf(message, mlen, "IP Rejected");

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1016,7 +1016,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 		}
 
 		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "action", "jsonrpc-authenticate");
-		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "client_ip", jsock->name);
+		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "client_address", jsock->name);
 
 		if (switch_xml_locate_user_merged("id", id, domain, NULL, &x_user, req_params) != SWITCH_STATUS_SUCCESS && !jsock->profile->blind_reg) {
 			*code = CODE_AUTH_FAILED;

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1038,8 +1038,15 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 				goto end;
 			}
 
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Scanning for error block.\n", jsock->name);
 			if ((x_param = switch_xml_child(x_user, "error"))) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Inside error block.\n", jsock->name);
 				error_code = switch_xml_attr_soft(x_param, "code");
+				if (!zstr(error_code)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Found error code: %s.\n", jsock->name, error_code);
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Could not found the error code.\n", jsock->name);
+				}
 			}
 
 			if ((x_params = switch_xml_child(x_user, "params"))) {
@@ -1086,6 +1093,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 			}
 
 			if (!zstr(error_code) && !strcasecmp(error_code, "ip-rejected")) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Action on error.\n", jsock->name);
 				r = SWITCH_FALSE;
 				*code = CODE_IP_REJECTED;
 				switch_snprintf(message, mlen, "IP Rejected");

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1016,6 +1016,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 		}
 
 		switch_event_add_header_string(req_params, SWITCH_STACK_BOTTOM, "action", "jsonrpc-authenticate");
+		switch_event_add_header_string(req_params, SWITCH_STACH_BOTTOM, "client_ip", jsock->name);
 
 		if (switch_xml_locate_user_merged("id", id, domain, NULL, &x_user, req_params) != SWITCH_STATUS_SUCCESS && !jsock->profile->blind_reg) {
 			*code = CODE_AUTH_FAILED;

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1038,14 +1038,10 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 				goto end;
 			}
 
-			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Scanning for error block.\n", jsock->name);
 			if ((x_param = switch_xml_child(x_user, "error"))) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Inside error block.\n", jsock->name);
 				error_code = switch_xml_attr_soft(x_param, "code");
 				if (!zstr(error_code)) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Found error code: %s.\n", jsock->name, error_code);
-				} else {
-					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Could not found the error code.\n", jsock->name);
 				}
 			}
 
@@ -1093,7 +1089,7 @@ static switch_bool_t check_auth(jsock_t *jsock, cJSON *params, int *code, char *
 			}
 
 			if (!zstr(error_code) && !strcasecmp(error_code, "ip-rejected")) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s Action on error.\n", jsock->name);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "%s IP Rejected\n", jsock->name);
 				r = SWITCH_FALSE;
 				*code = CODE_IP_REJECTED;
 				switch_snprintf(message, mlen, "IP Rejected");

--- a/src/mod/endpoints/mod_verto/mod_verto.h
+++ b/src/mod/endpoints/mod_verto/mod_verto.h
@@ -78,6 +78,7 @@
 #define CODE_AUTH_FAILED -32001
 #define CODE_SESSION_ERROR -32002
 #define CODE_DUPLICATE_SESSION -32003
+#define CODE_IP_REJECTED -32004
 
 #define MY_EVENT_CLIENT_CONNECT "verto::client_connect"
 #define MY_EVENT_CLIENT_DISCONNECT "verto::client_disconnect"


### PR DESCRIPTION
- Send `client_address` in the XML position authenticate request.
- Reject if the XML is returned with an `ip-rejected` error code.
```
<document type='freeswitch/xml'>
  <section name='directory'>
    <domain name='$${domain}'>
      <user id='agent-0002'>
        <error code='ip-rejected'/>
        <params>
        ...
        </params>
        <variables>
        ...
        </variables>
      </user>
    </domain>
  </section>
</document>
```